### PR TITLE
Adding suffix to s3boto3

### DIFF
--- a/openassessment/fileupload/backends/s3boto3.py
+++ b/openassessment/fileupload/backends/s3boto3.py
@@ -42,7 +42,7 @@ class Backend(BaseBackend):
         bucket_name, key_name = self._retrieve_parameters(key)
         try:
             conn = _connect_to_s3()
-            if not object_exists(conn, bucket_name, get_key_path(key_name)):
+            if not object_exists(conn, bucket_name, key_name):
                 return ""
             return conn.generate_presigned_url(
                 "get_object",

--- a/openassessment/fileupload/tests/test_api_s3boto3.py
+++ b/openassessment/fileupload/tests/test_api_s3boto3.py
@@ -38,11 +38,11 @@ class TestFileUploadService(TestCase):
         conn.create_bucket(Bucket="mybucket")
         conn.put_object(
             Bucket="mybucket",
-            Key="submissions_attachments/foo",
+            Key="submissions_attachments/foo/content",
             Body=b"How d'ya do?"
         )
         downloadUrl = api.get_download_url("foo")
-        self.assertIn("/submissions_attachments/foo", downloadUrl)
+        self.assertIn("/submissions_attachments/foo/content", downloadUrl)
 
     @mock_s3
     @override_settings(
@@ -55,7 +55,7 @@ class TestFileUploadService(TestCase):
         conn.create_bucket(Bucket="mybucket")
         conn.put_object(
             Bucket="mybucket",
-            Key="submissions_attachments/foo",
+            Key="submissions_attachments/foo/content",
             Body=b"Test"
         )
         result = api.remove_file("foo")


### PR DESCRIPTION
This prevent errors with the index 0, as it is not added, and we can't have [id, id/1, id/2]. We add the suffir so the result id are [id/content, id/1/content, id/2/content], preventing collisions.
